### PR TITLE
list-my-groups raises an error

### DIFF
--- a/announce/bellman.py
+++ b/announce/bellman.py
@@ -243,10 +243,10 @@ class Bellman:
             p.save()
 
     def group_exists(self, group_name):
-        return Group(group_name=group_name) in Group.objects.all()
+        return Group.objects.filter(group_name=group_name).exists()
 
     def person_exists(self):
-        return Person(person_id=self.user_id) in Person.objects.all()
+        return Person.objects.filter(person_id=self.user_id).exists()
 
     def name_changed(self):
         return self.user_name != (Person.objects
@@ -254,13 +254,8 @@ class Bellman:
                                         .person_name)
 
     def user_in_group(self, group_name):
-        return ((Person.objects
-                .get(person_id=self.user_id))
-                in
-                (Group.objects
-                    .get(group_name=group_name)
-                    .person_set
-                    .all()))
+        return Group.objects.filter(person__person_id=self.user_id,
+                                    group_name=group_name).exists()
 
     @csrf_exempt
     def make_group(self, group_name):

--- a/announce/migrations/0004_auto_20150708_0716.py
+++ b/announce/migrations/0004_auto_20150708_0716.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('announce', '0003_auto_20150624_1231'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='group',
+            name='id',
+            field=models.AutoField(auto_created=True, primary_key=True, default=0, serialize=False, verbose_name='ID'),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='group',
+            name='group_name',
+            field=models.CharField(max_length=200),
+        ),
+    ]

--- a/announce/migrations/0005_auto_20150708_0728.py
+++ b/announce/migrations/0005_auto_20150708_0728.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('announce', '0004_auto_20150708_0716'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='person',
+            name='id',
+            field=models.AutoField(auto_created=True, primary_key=True, default=0, serialize=False, verbose_name='ID'),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='person',
+            name='person_id',
+            field=models.CharField(max_length=200),
+        ),
+    ]

--- a/announce/models.py
+++ b/announce/models.py
@@ -3,7 +3,6 @@ from django.db import models
 
 class Group(models.Model):
     group_name = models.CharField(max_length=200)
-    group_name.primary_key = True
 
     def __unicode__(self):
         return self.group_name
@@ -11,7 +10,6 @@ class Group(models.Model):
 
 class Person(models.Model):
     person_id = models.CharField(max_length=200)
-    person_id.primary_key = True
     person_name = models.CharField(max_length=200)
     groups = models.ManyToManyField(Group)
 

--- a/announce/tests/test_bellman.py
+++ b/announce/tests/test_bellman.py
@@ -131,8 +131,9 @@ class AnnounceTestCase(TestCase):
         self.assertTrue('You\'ve been added to test_group' in
                         response.content)
         g = Group.objects.get(group_name='test_group')
-        self.assertTrue(Person(person_name='bob', person_id='test_id')
-                        in g.person_set.all())
+        self.assertTrue(
+            g.person_set.filter(
+                person_name='bob', person_id='test_id').exists())
         self.assertTrue(g in Person.objects.get(person_id='test_id')
                                    .groups.all())
         # already belongs to group
@@ -173,12 +174,9 @@ class AnnounceTestCase(TestCase):
 
     def test_create(self):
         c = Client()
-        g1 = Group(group_name='test_group')
-        g2 = Group(group_name='apple')
-        g3 = Group(group_name='banana')
-        self.assertTrue(g1 in Group.objects.all())
-        self.assertTrue(g2 in Group.objects.all())
-        self.assertTrue(g3 in Group.objects.all())
+        self.assertTrue(Group.objects.filter(group_name='test_group').exists())
+        self.assertTrue(Group.objects.filter(group_name='apple').exists())
+        self.assertTrue(Group.objects.filter(group_name='banana').exists())
 
         # no argument
         response = c.post('/announce/',
@@ -193,10 +191,10 @@ class AnnounceTestCase(TestCase):
         # standard use case
         response = c.post('/announce/',
                           make_post(text='create test_group2'))
-        self.assertTrue(Group(group_name='test_group2') in Group.objects.all())
-        self.assertTrue(g1 in Group.objects.all())
-        self.assertTrue(g2 in Group.objects.all())
-        self.assertTrue(g3 in Group.objects.all())
+        self.assertTrue(Group.objects.filter(group_name='test_group2').exists())
+        self.assertTrue(Group.objects.filter(group_name='test_group').exists())
+        self.assertTrue(Group.objects.filter(group_name='apple').exists())
+        self.assertTrue(Group.objects.filter(group_name='banana').exists())
 
     @patch.object(Bellman, 'send_announcement')
     def test_announce(self, mock_send_announcement):
@@ -209,12 +207,12 @@ class AnnounceTestCase(TestCase):
         # group name doesn't exist
         response = c.post('/announce/',
                           make_post(text='announce BLAH'))
-        print 'response', response.content
         self.assertTrue('The group \'BLAH\' does not exist' in
                         response.content)
         # no text message
         response = c.post('/announce/',
                           make_post(text='announce test_group'))
+        print response.content
         self.assertTrue('Please give me a message in your'
                         + 'bellman command:' in response.content)
         # standard test case

--- a/announce/tests/test_bellman.py
+++ b/announce/tests/test_bellman.py
@@ -191,7 +191,8 @@ class AnnounceTestCase(TestCase):
         # standard use case
         response = c.post('/announce/',
                           make_post(text='create test_group2'))
-        self.assertTrue(Group.objects.filter(group_name='test_group2').exists())
+        self.assertTrue(
+            Group.objects.filter(group_name='test_group2').exists())
         self.assertTrue(Group.objects.filter(group_name='test_group').exists())
         self.assertTrue(Group.objects.filter(group_name='apple').exists())
         self.assertTrue(Group.objects.filter(group_name='banana').exists())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 ignore = F403
-exclude = ve
+exclude = ve,**/migrations/*
 
 [pytest]
-addopts = --ignore=ve --ds=bellman.settings --verbose 
+addopts = --ignore=ve --ds=bellman.settings --verbose


### PR DESCRIPTION
```
Stacktrace (most recent call last):

  File "django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "announce/views.py", line 18, in handler
    return func(request, *args, **kwargs)
  File "announce/views.py", line 32, in announce
    app.execute()
  File "django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "announce/bellman.py", line 208, in execute
    self.list_my_groups()
  File "announce/bellman.py", line 55, in list_my_groups
    .get(person_id=self.user_id)
  File "django/db/models/query.py", line 162, in __iter__
    self._fetch_all()
  File "django/db/models/query.py", line 965, in _fetch_all
    self._result_cache = list(self.iterator())
  File "django/db/models/query.py", line 238, in iterator
    results = compiler.execute_sql()
  File "django/db/models/sql/compiler.py", line 840, in execute_sql
    cursor.execute(sql, params)
  File "django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "django/db/utils.py", line 97, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
```

and 

```
ProgrammingError: operator does not exist: character varying = integer
LINE 1: ...person_groups" ON ( "announce_group"."group_name" = "announc...
                                                             ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
```

on the query

```
u'SELECT "announce_group"."group_name" FROM "announce_group" INNER JOIN "announce_person_groups" ON ( "announce_group"."group_name" = "announce_person_groups"."group_id" ) WHERE "announce_person_groups"."person_id" = %s'
```
